### PR TITLE
change experimental module to models

### DIFF
--- a/fasttext_amazon_reviews/README.md
+++ b/fasttext_amazon_reviews/README.md
@@ -2,7 +2,7 @@
 
 This example demonstrates the use of the following module below from cleanlab:
 
-- [cleanlab.experimental.fasttext.py](https://github.com/cleanlab/cleanlab/blob/master/cleanlab/experimental/fasttext.py)
+- [cleanlab.models.fasttext.py](https://github.com/cleanlab/cleanlab/blob/master/cleanlab/models/fasttext.py)
 
 The code is adapted from cleanlab v1 examples (see `contrib/v1` folder).
 
@@ -20,4 +20,4 @@ Run bash script below to download all the data.
 $ bash ./download_data.sh
 ```
 
-Start Jupyter Lab and run the notebook: `amazon_pyx.ipynb`
+Start Jupyter Lab and run the notebook: `fasttext_amazon_reviews.ipynb`

--- a/fasttext_amazon_reviews/fasttext_amazon_reviews.ipynb
+++ b/fasttext_amazon_reviews/fasttext_amazon_reviews.ipynb
@@ -31,13 +31,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the follow [bash script]((https://github.com/cleanlab/examples/blob/master/fasttext_amazon_reviews/download_data.sh) to download all the data.\n",
+    "\n",
+    "```console\n",
+    "$ bash ./download_data.sh\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
-    "from cleanlab.experimental.fasttext import FastTextClassifier, data_loader\n",
+    "from cleanlab.models.fasttext import FastTextClassifier, data_loader\n",
     "import cleanlab\n",
     "import numpy as np\n",
     "from sklearn.model_selection import StratifiedKFold\n",
@@ -314,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {

--- a/fasttext_amazon_reviews/requirements.txt
+++ b/fasttext_amazon_reviews/requirements.txt
@@ -1,3 +1,4 @@
+# This notebook currently requires the latest developer version of cleanlab: pip install git+https://github.com/cleanlab/cleanlab.git
 fasttext
 numpy==1.21.6
 scikit_learn==1.0.2

--- a/huggingface_keras_imdb/huggingface_keras_imdb.ipynb
+++ b/huggingface_keras_imdb/huggingface_keras_imdb.ipynb
@@ -47,7 +47,7 @@
     "from sklearn.metrics import accuracy_score\n",
     "import os\n",
     "\n",
-    "from cleanlab.experimental.keras import KerasWrapperModel\n",
+    "from cleanlab.models.keras import KerasWrapperModel\n",
     "from cleanlab.classification import CleanLearning\n",
     "\n",
     "logging.set_verbosity(40)\n",
@@ -470,7 +470,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {

--- a/huggingface_keras_imdb/requirements.txt
+++ b/huggingface_keras_imdb/requirements.txt
@@ -1,4 +1,4 @@
-ipywidgets==8.0.2
+# This notebook currently requires the latest developer version of cleanlab: pip install git+https://github.com/cleanlab/cleanlab.gitipywidgets==8.0.2
 numpy>=1.22.0
 scikit_learn==1.0.2
 tensorflow==2.9.2 # for Macs with Apple silicon : tensorflow-macos==2.9.2 and tensorflow-metal==0.5.1

--- a/huggingface_keras_imdb/requirements.txt
+++ b/huggingface_keras_imdb/requirements.txt
@@ -1,4 +1,5 @@
-# This notebook currently requires the latest developer version of cleanlab: pip install git+https://github.com/cleanlab/cleanlab.gitipywidgets==8.0.2
+# This notebook currently requires the latest developer version of cleanlab: pip install git+https://github.com/cleanlab/cleanlab.git
+ipywidgets==8.0.2
 numpy>=1.22.0
 scikit_learn==1.0.2
 tensorflow==2.9.2 # for Macs with Apple silicon : tensorflow-macos==2.9.2 and tensorflow-metal==0.5.1


### PR DESCRIPTION
Changing function import namespace from `experimental` to `models` following migration in https://github.com/cleanlab/cleanlab/pull/601